### PR TITLE
feat: Add loading to dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Walter</title>
+    <title>WALTER</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -8,12 +8,16 @@ import PortfolioStockLineChartWidget from '../portfolio/PortfolioStockLineChartW
 import PortfolioDataGrid from '../portfolio/PortfolioDataGrid';
 
 const Dashboard: React.FC = () => {
+  const [loading, setLoading] = useState(false);
   const [stocks, setStocks] = useState<PortfolioStock[]>([]);
 
   useEffect(() => {
-    WalterAPI.getPortfolio().then((response: GetPortfolioResponse) => {
-      setStocks(response.getStocks());
-    });
+    setLoading(true);
+    WalterAPI.getPortfolio()
+      .then((response: GetPortfolioResponse) => {
+        setStocks(response.getStocks());
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   return (
@@ -35,7 +39,7 @@ const Dashboard: React.FC = () => {
             boxShadow: 3,
           }}
         >
-          <PortfolioPieChart stocks={stocks} />
+          <PortfolioPieChart loading={loading} stocks={stocks} />
         </Grid>
         <Grid
           size={6}
@@ -45,7 +49,7 @@ const Dashboard: React.FC = () => {
             boxShadow: 3,
           }}
         >
-          <PortfolioStockLineChartWidget stocks={stocks} />
+          <PortfolioStockLineChartWidget loading={loading} stocks={stocks} />
         </Grid>
         <Grid
           size={12}
@@ -55,7 +59,7 @@ const Dashboard: React.FC = () => {
             boxShadow: 3,
           }}
         >
-          <PortfolioDataGrid stocks={stocks} />
+          <PortfolioDataGrid loading={loading} stocks={stocks} />
         </Grid>
       </Grid>
     </Box>

--- a/src/components/portfolio/PortfolioDataGrid.tsx
+++ b/src/components/portfolio/PortfolioDataGrid.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Box } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import { PortfolioStock } from '../../api/GetPortfolio';
 
 interface PortfolioDataGridProps {
+  loading: boolean;
   stocks: PortfolioStock[];
 }
 
@@ -17,27 +18,75 @@ interface PortfolioDataGridRow {
 }
 
 const PortfolioDataGrid: React.FC<PortfolioDataGridProps> = (props) => {
+  const USDollar = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+
   function getColumns(): GridColDef<PortfolioDataGridRow>[] {
     return [
-      { field: 'id', headerName: 'Stock', width: 300 },
-      { field: 'company', headerName: 'Company', width: 300 },
+      {
+        field: 'id',
+        headerName: 'Stock',
+        width: 300,
+        renderHeader: () => (
+          <strong
+            style={{ fontFamily: 'Raleway, sans-serif', fontSize: '16px' }}
+          >
+            Stock
+          </strong>
+        ),
+      },
+      {
+        field: 'company',
+        headerName: 'Company',
+        width: 300,
+        renderHeader: () => (
+          <strong
+            style={{ fontFamily: 'Raleway, sans-serif', fontSize: '16px' }}
+          >
+            Company
+          </strong>
+        ),
+      },
       {
         field: 'quantity',
         headerName: 'Number of Shares',
         type: 'number',
         width: 300,
+        renderHeader: () => (
+          <strong
+            style={{ fontFamily: 'Raleway, sans-serif', fontSize: '16px' }}
+          >
+            Shares
+          </strong>
+        ),
       },
       {
         field: 'price',
         headerName: 'Price',
         type: 'string',
         width: 300,
+        renderHeader: () => (
+          <strong
+            style={{ fontFamily: 'Raleway, sans-serif', fontSize: '16px' }}
+          >
+            Price
+          </strong>
+        ),
       },
       {
         field: 'equity',
         headerName: 'Equity',
         type: 'string',
         width: 300,
+        renderHeader: () => (
+          <strong
+            style={{ fontFamily: 'Raleway, sans-serif', fontSize: '16px' }}
+          >
+            Equity
+          </strong>
+        ),
       },
     ];
   }
@@ -49,31 +98,48 @@ const PortfolioDataGrid: React.FC<PortfolioDataGridProps> = (props) => {
         id: stock.symbol,
         symbol: stock.symbol,
         company: stock.company,
-        quantity: `${stock.quantity.toFixed(2)}`,
-        price: `$ ${stock.price.toFixed(2)}`,
-        equity: `$ ${stock.equity.toFixed(2)}`,
+        quantity: `${stock.quantity.toLocaleString('en-US', { maximumFractionDigits: 2 })}`,
+        price: `${USDollar.format(stock.price)}`,
+        equity: `${USDollar.format(stock.equity)}`,
       });
     }
     return rows;
   }
 
   return (
-    <Box sx={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={getRows()}
-        columns={getColumns()}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 5,
-            },
-          },
-        }}
-        pageSizeOptions={[5]}
-        checkboxSelection
-        disableRowSelectionOnClick
-      />
-    </Box>
+    <>
+      {props.loading ? (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: 400,
+            width: '100%',
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Box sx={{ height: 400, width: '100%' }}>
+          <DataGrid
+            rows={getRows()}
+            columns={getColumns()}
+            initialState={{
+              pagination: {
+                paginationModel: {
+                  pageSize: 5,
+                },
+              },
+            }}
+            pageSizeOptions={[5]}
+            checkboxSelection
+            disableRowSelectionOnClick
+          />
+        </Box>
+      )}
+      );
+    </>
   );
 };
 

--- a/src/components/portfolio/PortfolioPieChart.tsx
+++ b/src/components/portfolio/PortfolioPieChart.tsx
@@ -1,17 +1,24 @@
 import * as React from 'react';
 import { pieArcLabelClasses, PieChart } from '@mui/x-charts/PieChart';
-import { Container, Typography } from '@mui/material';
+import { CircularProgress, Container, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
 
 const colors = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0'];
 
 interface PortfolioProps {
+  loading: boolean;
   stocks: any[];
 }
 
-const PortfolioPieChart: React.FC<PortfolioProps> = ({ stocks }) => {
+const PortfolioPieChart: React.FC<PortfolioProps> = (props: PortfolioProps) => {
+  const USDollar = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+
   const graphStocks = () => {
     const data = [];
-    for (const stock of stocks) {
+    for (const stock of props.stocks) {
       data.push({
         id: stock.symbol,
         value: stock.equity,
@@ -24,26 +31,40 @@ const PortfolioPieChart: React.FC<PortfolioProps> = ({ stocks }) => {
   return (
     <Container>
       <Typography variant="h6">Portfolio</Typography>
-      <PieChart
-        series={[
-          {
-            data: graphStocks(),
-            innerRadius: 10,
-            paddingAngle: 2,
-            arcLabel: (value) => `$ ${value.value.toFixed(2)}`,
-            arcLabelMinAngle: 35,
-            valueFormatter: (value) => `$ ${value.value.toFixed(2)}`,
-          },
-        ]}
-        sx={{
-          [`& .${pieArcLabelClasses.root}`]: {
-            fontWeight: 'bold',
-          },
-        }}
-        width={600}
-        height={400}
-        colors={colors}
-      />
+      {props.loading ? (
+        <Box
+          width={600}
+          height={400}
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <PieChart
+          series={[
+            {
+              data: graphStocks(),
+              innerRadius: 10,
+              paddingAngle: 2,
+              arcLabel: (value) => `${USDollar.format(value.value)}`,
+              arcLabelMinAngle: 35,
+              valueFormatter: (value) => `${USDollar.format(value.value)}`,
+            },
+          ]}
+          sx={{
+            [`& .${pieArcLabelClasses.root}`]: {
+              fontWeight: 'bold',
+            },
+          }}
+          width={600}
+          height={400}
+          colors={colors}
+        />
+      )}
     </Container>
   );
 };

--- a/src/components/portfolio/PortfolioStockLineChart.tsx
+++ b/src/components/portfolio/PortfolioStockLineChart.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { Price } from '../../api/GetPrices';
 import dayjs from 'dayjs';
-import { Container, Typography } from '@mui/material';
+import { CircularProgress, Container, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
 
 interface PortfolioStockLineChartProps {
+  loading: boolean;
   stock: string;
   prices: Price[];
 }
@@ -23,28 +25,42 @@ const PortfolioStockLineChart: React.FC<PortfolioStockLineChartProps> = (
   return (
     <Container>
       <Typography variant="h6">{props.stock} Stocks</Typography>
-      <LineChart
-        xAxis={[
-          {
-            data: getTimestamps(),
-            valueFormatter: (v) => dayjs(v).format('YYYY-MM-DD'),
-          },
-        ]}
-        yAxis={[
-          {
-            valueFormatter: (value) => `$ ${value.toFixed(2)}`,
-          },
-        ]}
-        series={[
-          {
-            data: getPrices(),
-            valueFormatter: (v) => `$ ${v?.toFixed(2)}`,
-          },
-        ]}
-        width={700}
-        height={400}
-        grid={{ vertical: true, horizontal: true }}
-      />
+      {props.loading ? (
+        <Box
+          width={600}
+          height={400}
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <LineChart
+          xAxis={[
+            {
+              data: getTimestamps(),
+              valueFormatter: (v) => dayjs(v).format('YYYY-MM-DD'),
+            },
+          ]}
+          yAxis={[
+            {
+              valueFormatter: (value) => `$ ${value.toFixed(2)}`,
+            },
+          ]}
+          series={[
+            {
+              data: getPrices(),
+              valueFormatter: (v) => `$ ${v?.toFixed(2)}`,
+            },
+          ]}
+          width={700}
+          height={400}
+          grid={{ vertical: true, horizontal: true }}
+        />
+      )}
     </Container>
   );
 };

--- a/src/components/portfolio/PortfolioStockLineChartWidget.tsx
+++ b/src/components/portfolio/PortfolioStockLineChartWidget.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { Price } from '../../api/GetPrices';
-import { Container, Pagination } from '@mui/material';
+import { CircularProgress, Container, Pagination } from '@mui/material';
 import PortfolioStockLineChart from './PortfolioStockLineChart';
 import { PortfolioStock } from '../../api/GetPortfolio';
 import { WalterAPI } from '../../api/WalterAPI';
+import Box from '@mui/material/Box';
 
 interface PortfolioStockLineChartWidgetProps {
+  loading: boolean;
   stocks: PortfolioStock[];
 }
 
@@ -15,36 +17,51 @@ const PortfolioStockLineChartWidget: React.FC<
 > = (props) => {
   const [page, setPage] = useState<number>(1);
   const [stock, setStock] = useState<string>('');
-  const [stocks, setStocks] = useState<PortfolioStock[]>([]);
   const [prices, setPrices] = useState<Price[]>([]);
 
   useEffect(() => {
-    setStocks(props.stocks);
-  }, [props.stocks]);
-
-  useEffect(() => {
-    if (stocks !== undefined && stocks.length > 0) {
-      setStock(stocks[page - 1].symbol);
-      WalterAPI.getPrices(stocks[page - 1].symbol).then((response) => {
+    if (props.stocks !== undefined && props.stocks.length > 0) {
+      setStock(props.stocks[page - 1].symbol);
+      WalterAPI.getPrices(props.stocks[page - 1].symbol).then((response) => {
         setPrices(response.getPrices());
       });
     }
-  }, [page]);
+  }, [page, props.stocks]);
 
   const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
   };
 
   return (
-    <Container>
-      <PortfolioStockLineChart stock={stock} prices={prices} />
-      <Pagination
-        count={stocks.length}
-        color="primary"
-        page={page}
-        onChange={handleChange}
-      />
-    </Container>
+    <>
+      {props.loading ? (
+        <Box
+          width={600}
+          height={400}
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Container>
+          <PortfolioStockLineChart
+            loading={props.loading}
+            stock={stock}
+            prices={prices}
+          />
+          <Pagination
+            count={props.stocks.length}
+            color="primary"
+            page={page}
+            onChange={handleChange}
+          />
+        </Container>
+      )}
+    </>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #222222;
 }
 
 code {


### PR DESCRIPTION
This PR adds loading to the user dashboard view of their portfolio. 

This is helpful because it displays to user the progress of `WalterFrontend` requesting portfolio details for the authenticated user from `WalterBackend`. 

With the low number of users (just me lol) Lambda cold start API latency can be pretty bad (e.g. >5s) so a circular progress bar is kind of essential until that approves as there is a lot of waiting :/