### PR TITLE
feat: Add user not subscribed alert

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import SendVerifyEmail from './components/verify/SendVerifyEmail';
 import NewslettersPage from './pages/NewslettersPage';
 import PortfolioDashboardPage from './pages/PortfolioDashboardPage';
 import UnsubscribePage from './pages/UnsubscribePage';
+import UserNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
+import userNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
 
 /**
  * Walter App
@@ -44,6 +46,8 @@ const App: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [authenticated, setAuthenticated] = useState<boolean>(false);
   const [userNotVerifiedAlert, setUserNotVerifiedAlert] =
+    useState<boolean>(false);
+  const [userNotSubscribedAlert, setUserNotSubscribeAlert] =
     useState<boolean>(false);
 
   /**
@@ -62,6 +66,7 @@ const App: React.FC = () => {
       .then((response: GetUserResponse) => {
         setAuthenticated(response.isAuthenticated());
         setUserNotVerifiedAlert(response.isNotVerified());
+        setUserNotSubscribeAlert(response.isNotSubscribed());
       })
       .catch((error: any) => setAuthenticated(false))
       .finally(() => setLoading(false));
@@ -105,6 +110,10 @@ const App: React.FC = () => {
             <UserNotVerifiedAlert
               userNotVerified={userNotVerifiedAlert}
               setUserNotVerifiedAlert={setUserNotVerifiedAlert}
+            />
+            <UserNotSubscribedAlert
+              userNotSubscribed={userNotSubscribedAlert}
+              setUserNotSubscribedAlert={setUserNotSubscribeAlert}
             />
           </>
         )}

--- a/src/api/methods/GetUser.ts
+++ b/src/api/methods/GetUser.ts
@@ -11,6 +11,7 @@ export interface User {
   email: string;
   username: string;
   verified: boolean;
+  subscribed: boolean;
 }
 
 /**
@@ -41,22 +42,30 @@ export class GetUserResponse extends WalterAPIResponseBase {
     return !this.user.verified && this.isAuthenticated();
   }
 
+  public isNotSubscribed(): boolean {
+    console.log(this.user);
+    return !this.user.subscribed && this.isAuthenticated();
+  }
+
   public getMessage(): string {
     return this.message;
   }
 
   private initUser(data?: any): User {
+    console.log(data);
     if (data === null || data === undefined) {
       return {
         email: '',
         username: '',
         verified: false,
+        subscribed: false,
       };
     }
     return {
       email: data.email,
       username: data.username,
       verified: data.verified,
+      subscribed: data.subscribed,
     };
   }
 }

--- a/src/components/alerts/UserNotSubscribedAlert.tsx
+++ b/src/components/alerts/UserNotSubscribedAlert.tsx
@@ -1,0 +1,46 @@
+import { Alert, Snackbar } from '@mui/material';
+import React from 'react';
+
+/**
+ * UserNotSubscribedAlertProps
+ *
+ * The props for the user unsubscribed alert.
+ */
+interface UserNotSubscribedAlertProps {
+  userNotSubscribed: boolean;
+  setUserNotSubscribedAlert: (userNotSubscribed: boolean) => void;
+}
+
+/**
+ * UserNotSubscribedAlert
+ *
+ * This component alerts the user with a popup notification if
+ * they are not subscribed to Walter's newsletter. This ensures
+ * that users are encouraged to subscribe and actually reap the
+ * benefit of Walter, daily portfolio emails.
+ *
+ * @param props
+ * @constructor
+ */
+const UserNotSubscribedAlert: React.FC<UserNotSubscribedAlertProps> = (
+  props,
+) => {
+  return (
+    <>
+      <Snackbar
+        open={props.userNotSubscribed}
+        onClose={(e) => props.setUserNotSubscribedAlert(false)}
+      >
+        <Alert
+          onClose={(e) => props.setUserNotSubscribedAlert(false)}
+          severity="warning"
+        >
+          User not subscribed! Subscribe to the newsletter for daily portfolio
+          updates.
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default UserNotSubscribedAlert;

--- a/src/components/alerts/UserNotVerifiedAlert.tsx
+++ b/src/components/alerts/UserNotVerifiedAlert.tsx
@@ -20,6 +20,7 @@ interface UserNotVerifiedAlertProps {
  * email address has not been successfully verified. This ensures
  * that users are aware if Walter can send their daily newsletter.
  *
+ * @param props
  * @constructor
  */
 const UserNotVerifiedAlert: React.FC<UserNotVerifiedAlertProps> = (props) => {


### PR DESCRIPTION
This PR adds a user not subscribed alert so that users are notified upon successful login to Walter that they are not subscribed.

Users can navigate to a different page and subscribe to get daily portfolio updates which is the real purpose of Walter. 

Similar to the user not verified alerts that Walter enforces before sending portfolio emails to avoid email spamming accounts. 