### PR TITLE
feat: Add stock dashboard page rough draft

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   REGISTER_PAGE,
   RESET_PASSWORD_PAGE,
   SEND_VERIFY_EMAIL_PAGE,
+  STOCK_DASHBOARD_PAGE,
   UNSUBSCRIBE_PAGE,
   VERIFY_EMAIL_PAGE,
 } from './pages/common/Pages';
@@ -32,6 +33,7 @@ import PortfolioDashboardPage from './pages/PortfolioDashboardPage';
 import UnsubscribePage from './pages/UnsubscribePage';
 import UserNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
 import userNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
+import StockDashboardPage from './pages/StockDashboardPage';
 
 /**
  * Walter App
@@ -106,6 +108,10 @@ const App: React.FC = () => {
                 element={<SendChangePasswordEmail />}
               />
               <Route path={UNSUBSCRIBE_PAGE} element={<UnsubscribePage />} />
+              <Route
+                path={STOCK_DASHBOARD_PAGE}
+                element={<StockDashboardPage />}
+              />
             </Routes>
             <UserNotVerifiedAlert
               userNotVerified={userNotVerifiedAlert}

--- a/src/api/WalterAPI.ts
+++ b/src/api/WalterAPI.ts
@@ -26,6 +26,10 @@ import {
 } from './methods/SendVerifyEmail';
 import { subscribe, SubscribeResponse } from './methods/Subscribe';
 import { unsubscribe, UnsubscribeResponse } from './methods/Unsubscribe';
+import {
+  getNewsSummary,
+  GetNewsSummaryResponse,
+} from './methods/GetNewsSummary';
 
 /**
  * Walter API
@@ -79,6 +83,17 @@ export class WalterAPI {
    */
   public static async getStock(symbol: string): Promise<GetStockResponse> {
     return getStock(WalterAPI.ENDPOINT, symbol);
+  }
+
+  /**
+   * Get AI news summary of articles related to the given stock
+   *
+   * @param symbol The symbol of the stock.
+   */
+  public static async getNewsSummary(
+    symbol: string,
+  ): Promise<GetNewsSummaryResponse> {
+    return getNewsSummary(WalterAPI.ENDPOINT, symbol);
   }
 
   /**

--- a/src/api/common/Methods.ts
+++ b/src/api/common/Methods.ts
@@ -17,3 +17,4 @@ export const VERIFY_EMAIL_METHOD: string = 'VerifyEmail';
 export const CHANGE_PASSWORD_METHOD: string = 'ChangePassword';
 export const SEND_CHANGE_PASSWORD_EMAIL_METHOD: string =
   'SendChangePasswordEmail';
+export const GET_NEWS_SUMMARY_METHOD: string = 'GetNewsSummary';

--- a/src/api/methods/GetNewsSummary.ts
+++ b/src/api/methods/GetNewsSummary.ts
@@ -1,0 +1,58 @@
+import { WalterAPIResponseBase } from '../common/Response';
+import { GET_NEWS_SUMMARY_METHOD } from '../common/Methods';
+import axios, { AxiosResponse } from 'axios';
+import { GetStockResponse } from './GetStock';
+
+/**
+ * GetNewsSummaryResponse
+ *
+ * The response model object for the WalterAPI GetNewsSummary. This API
+ * parses the latest, relevant news articles to create a summary of news
+ * related to the given stock. This API aims to give users AI summaries
+ * of market movements related to specific companies.
+ */
+export class GetNewsSummaryResponse extends WalterAPIResponseBase {
+  private readonly summary: string | undefined;
+
+  constructor(status: string, message: string, data?: any) {
+    super(GET_NEWS_SUMMARY_METHOD, status, message);
+    this.summary = this.parseData(data);
+  }
+
+  getSummary(): string | undefined {
+    return this.summary;
+  }
+
+  private parseData(data: any): string | undefined {
+    if (data === undefined) {
+      return data;
+    }
+    return data.summary;
+  }
+}
+
+/**
+ * Invoke the GetNewsSummary API to get a summary of news related to the given
+ * stock.
+ *
+ * @param endpoint The GetNewsSummary API endpoint.
+ * @param symbol   The symbol of the stock to get a news summary.
+ */
+export async function getNewsSummary(
+  endpoint: string,
+  symbol: string,
+): Promise<GetNewsSummaryResponse> {
+  // TODO: This should be a GET method with a URL query param
+  const response: AxiosResponse = await axios({
+    method: 'POST',
+    url: `${endpoint}/news`,
+    data: {
+      stock: symbol,
+    },
+  });
+  return new GetNewsSummaryResponse(
+    response.data['Status'],
+    response.data['Message'],
+    response.data['Data'],
+  );
+}

--- a/src/api/methods/GetStock.ts
+++ b/src/api/methods/GetStock.ts
@@ -11,6 +11,12 @@ import { GET_STOCK_METHOD } from '../common/Methods';
 export interface Stock {
   symbol: string;
   company: string;
+  description: string;
+  exchange: string;
+  sector: string;
+  industry: string;
+  official_site: string;
+  address: string;
 }
 
 /**
@@ -20,14 +26,14 @@ export interface Stock {
  * stored in WalterDB for a given stock symbol.
  */
 export class GetStockResponse extends WalterAPIResponseBase {
-  private readonly stock: Stock | null;
+  private readonly stock: Stock | undefined;
 
   constructor(status: string, message: string, data?: any) {
     super(GET_STOCK_METHOD, status, message);
     this.stock = this.parseData(data)!;
   }
 
-  public getStock(): Stock | null {
+  public getStock(): Stock | undefined {
     return this.stock;
   }
 

--- a/src/components/stock/StockNewsSummary.tsx
+++ b/src/components/stock/StockNewsSummary.tsx
@@ -1,0 +1,38 @@
+import LoadingCircularProgress from '../progress/LoadingCircularProgress';
+import React from 'react';
+import { Container, CssBaseline } from '@mui/material';
+import Box from '@mui/material/Box';
+
+interface StockNewsSummaryProps {
+  loading: boolean;
+  summary: string | undefined;
+}
+
+const StockNewsSummary: React.FC<StockNewsSummaryProps> = (props) => {
+  return (
+    <>
+      {props.loading || props.summary === undefined ? (
+        <LoadingCircularProgress />
+      ) : (
+        <Container maxWidth="md">
+          <CssBaseline />
+          <Box
+            sx={{
+              mt: 20,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              borderRadius: 2,
+              boxShadow: 3,
+              padding: 2,
+            }}
+          >
+            <p>{props.summary}</p>
+          </Box>
+        </Container>
+      )}
+    </>
+  );
+};
+
+export default StockNewsSummary;

--- a/src/components/stock/StockOverview.tsx
+++ b/src/components/stock/StockOverview.tsx
@@ -1,0 +1,78 @@
+import LoadingCircularProgress from '../progress/LoadingCircularProgress';
+import { Stock } from '../../api/methods/GetStock';
+import React from 'react';
+import { Container, CssBaseline, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+
+/**
+ * StockOverviewProps
+ *
+ * The props used to display the overview of a stock. This
+ * overview is intended to give users quick information about
+ * a company on a stock dashboard page.
+ */
+interface StockOverviewProps {
+  loading: boolean;
+  stock: Stock | undefined;
+}
+
+/**
+ * StockOverview
+ *
+ * This component displays the overview of a stock in a card
+ * format and is to be used for the stock dashboard page.
+ *
+ * @param props
+ * @constructor
+ */
+const StockOverview: React.FC<StockOverviewProps> = (props) => {
+  return (
+    <>
+      {props.loading || props.stock === undefined ? (
+        <LoadingCircularProgress />
+      ) : (
+        <Container maxWidth="md">
+          <CssBaseline />
+          <Box
+            sx={{
+              mt: 20,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              borderRadius: 2,
+              boxShadow: 3,
+              padding: 2,
+            }}
+          >
+            <Typography variant="subtitle1">
+              Symbol: {props.stock.symbol}
+            </Typography>
+            <Typography variant="subtitle1">
+              Company: {props.stock.company}
+            </Typography>
+            <Typography variant="subtitle1">
+              Description: {props.stock.description}
+            </Typography>
+            <Typography variant="subtitle1">
+              Exchange: {props.stock.exchange}
+            </Typography>
+            <Typography variant="subtitle1">
+              Sector: {props.stock.sector}
+            </Typography>
+            <Typography variant="subtitle1">
+              Industry: {props.stock.industry}
+            </Typography>
+            <Typography variant="subtitle1">
+              Official Site: {props.stock.official_site}
+            </Typography>
+            <Typography variant="subtitle1">
+              Address: {props.stock.address}
+            </Typography>
+          </Box>
+        </Container>
+      )}
+    </>
+  );
+};
+
+export default StockOverview;

--- a/src/pages/StockDashboardPage.tsx
+++ b/src/pages/StockDashboardPage.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { Params, useParams } from 'react-router-dom';
+import { WalterAPI } from '../api/WalterAPI';
+import { GetStockResponse, Stock } from '../api/methods/GetStock';
+import StockOverview from '../components/stock/StockOverview';
+import { GetNewsSummaryResponse } from '../api/methods/GetNewsSummary';
+import StockNewsSummary from '../components/stock/StockNewsSummary';
+import { GetPricesResponse, Price } from '../api/methods/GetPrices';
+
+const StockDashboardPage: React.FC = (props) => {
+  const params: Readonly<Params> = useParams();
+  const [stockLoading, setStockLoading] = useState(false);
+  const [pricesLoading, setPricesLoading] = useState(false);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [stock, setStock] = useState<Stock>();
+  const [prices, setPrices] = useState<Price[]>([]);
+  const [summary, setSummary] = useState<string>();
+
+  useEffect(() => {
+    getStockOverview();
+    getStockPrices();
+    getStockNewsSummary();
+  }, []);
+
+  const getStockOverview = () => {
+    setStockLoading(true);
+    WalterAPI.getStock(params.symbol as string)
+      .then((response: GetStockResponse) => {
+        setStock(response.getStock());
+      })
+      .finally(() => {
+        setStockLoading(false);
+      });
+  };
+
+  const getStockPrices = () => {
+    setPricesLoading(true);
+    WalterAPI.getPrices(params.symbol as string)
+      .then((response: GetPricesResponse) => {
+        setPrices(response.getPrices());
+      })
+      .finally(() => {
+        setPricesLoading(false);
+      });
+  };
+
+  const getStockNewsSummary = () => {
+    setSummaryLoading(true);
+    WalterAPI.getNewsSummary(params.symbol as string)
+      .then((response: GetNewsSummaryResponse) => {
+        setSummary(response.getSummary());
+      })
+      .finally(() => {
+        setSummaryLoading(false);
+      });
+  };
+
+  return (
+    <>
+      <StockOverview loading={stockLoading} stock={stock} />
+      <StockNewsSummary loading={summaryLoading} summary={summary} />
+    </>
+  );
+};
+
+export default StockDashboardPage;

--- a/src/pages/common/Pages.ts
+++ b/src/pages/common/Pages.ts
@@ -11,3 +11,4 @@ export const VERIFY_EMAIL_PAGE = '/verify';
 export const CHANGE_PASSWORD_PAGE = '/password';
 export const RESET_PASSWORD_PAGE = '/reset-password';
 export const UNSUBSCRIBE_PAGE = '/unsubscribe';
+export const STOCK_DASHBOARD_PAGE = '/stocks/:symbol';


### PR DESCRIPTION
This PR adds the rough draft of the new stock dashboard.

This feature utilizes URL params to route to stock specific dashboard pages that give the users an overview and news summary about the given stock.

The goal will be to add some more visually pleasing metrics and clean up the presentation but this PR serves as implementing the initial wiring. 