### PR TITLE
feat: Add links from portfolio dashboard to stock overviews

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -12,7 +12,6 @@ import {
   LOGIN_PAGE,
   NEWSLETTER_PAGE,
   REGISTER_PAGE,
-  SEND_VERIFY_EMAIL_PAGE,
 } from '../../pages/common/Pages';
 import SendIcon from '@mui/icons-material/Send';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
@@ -24,7 +23,6 @@ import SearchBar from './SearchBar';
 import theme from '../../theme/Theme';
 import MenuIcon from '@mui/icons-material/Menu';
 import DrawerButton from './DrawerButton';
-import HowToRegIcon from '@mui/icons-material/HowToReg';
 import { WALTER_TOKEN_NAME } from '../../constants/Constants';
 
 /**

--- a/src/components/portfolio/piechart/PortfolioPieChart.tsx
+++ b/src/components/portfolio/piechart/PortfolioPieChart.tsx
@@ -5,6 +5,7 @@ import LoadingCircularProgress from '../../progress/LoadingCircularProgress';
 import { US_DOLLAR } from '../../../constants/Constants';
 import { PortfolioStock } from '../../../api/methods/GetPortfolio';
 import theme from '../../../theme/Theme';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * The colors utilized for the pie chart.
@@ -33,6 +34,7 @@ interface PortfolioPieChartProps {
  */
 const PortfolioPieChart: React.FC<PortfolioPieChartProps> = (props) => {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const navigate = useNavigate();
 
   const graphStocks = () => {
     return props.stocks.map((stock) => ({
@@ -40,6 +42,11 @@ const PortfolioPieChart: React.FC<PortfolioPieChartProps> = (props) => {
       value: stock.equity,
       label: stock.symbol,
     }));
+  };
+
+  const handleItemClick = (event: any, params: any) => {
+    const stock = props.stocks[params.dataIndex].symbol.toLowerCase();
+    navigate(`/stocks/${stock}`);
   };
 
   return (
@@ -80,6 +87,7 @@ const PortfolioPieChart: React.FC<PortfolioPieChartProps> = (props) => {
             slotProps={{ legend: { hidden: isMobile } }}
             height={400}
             colors={colors}
+            onItemClick={handleItemClick}
           />
         </Container>
       )}

--- a/src/components/stock/StockLineGraph.tsx
+++ b/src/components/stock/StockLineGraph.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { FC } from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+import dayjs from 'dayjs';
+import { Container, Card, CardContent, Typography, Box } from '@mui/material';
+import { Stock } from '../../api/methods/GetStock';
+import { US_DOLLAR } from '../../constants/Constants';
+import { Price } from '../../api/methods/GetPrices';
+
+/**
+ * StockLineGraphProps
+ */
+interface StockLineGraphProps {
+  loading: boolean;
+  stock: Stock | undefined;
+  prices: Price[];
+}
+
+const StockLineGraph: FC<StockLineGraphProps> = (
+  props: StockLineGraphProps,
+) => {
+  /**
+   * Get the timestamps from the prices in the given props.
+   */
+  const getTimestamps = () => {
+    return props.prices.map((price: Price) =>
+      new Date(price.timestamp).getTime(),
+    );
+  };
+
+  /**
+   * Get the prices from the prices in the given props.
+   */
+  const getPrices = () => {
+    return props.prices.map((price: Price) => price.price);
+  };
+
+  /**
+   * Get the start price of the stock at the start of the time period.
+   */
+  const getStartPrice = () => {
+    if (props.prices.length === 0) {
+      return 0;
+    }
+    return props.prices[0].price;
+  };
+
+  /**
+   * Get the end price of the stock at the end of the time period.
+   */
+  const getEndPrice = () => {
+    if (props.prices.length === 0) {
+      return 0;
+    }
+    return props.prices[props.prices.length - 1].price;
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Card sx={{ borderRadius: 2, boxShadow: 3 }}>
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mb: 3,
+            }}
+          >
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{ fontWeight: 'bold' }}
+            >
+              {props.stock?.company} ({props.stock?.symbol})
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {`Start: ${US_DOLLAR.format(getStartPrice())} | End: ${US_DOLLAR.format(getEndPrice())}`}
+            </Typography>
+          </Box>
+
+          <LineChart
+            xAxis={[
+              {
+                data: getTimestamps(),
+                valueFormatter: (v) => dayjs(v).format('MMM D, YYYY'),
+                tickLabelStyle: {
+                  fontSize: 12,
+                  fontFamily: 'Raleway, sans-serif',
+                  fontWeight: 'bold',
+                },
+              },
+            ]}
+            yAxis={[
+              {
+                valueFormatter: (value) => `${US_DOLLAR.format(value)}`,
+                tickLabelStyle: {
+                  fontSize: 12,
+                  fontFamily: 'Raleway, sans-serif',
+                  fontWeight: 'bold',
+                },
+              },
+            ]}
+            series={[
+              {
+                data: getPrices(),
+                valueFormatter: (v) => `${US_DOLLAR.format(v as number)}`,
+                color: '#257180',
+                showMark: false,
+              },
+            ]}
+            height={400}
+            margin={{ left: 60, right: 60, top: 60, bottom: 60 }}
+            grid={{ vertical: true, horizontal: true }}
+          />
+        </CardContent>
+      </Card>
+    </Container>
+  );
+};
+
+export default StockLineGraph;

--- a/src/components/stock/StockNewsSummary.tsx
+++ b/src/components/stock/StockNewsSummary.tsx
@@ -1,37 +1,64 @@
-import LoadingCircularProgress from '../progress/LoadingCircularProgress';
 import React from 'react';
-import { Container, CssBaseline } from '@mui/material';
-import Box from '@mui/material/Box';
+import {
+  Container,
+  CssBaseline,
+  Typography,
+  Card,
+  CardContent,
+  Box,
+  Skeleton,
+} from '@mui/material';
+import LoadingCircularProgress from '../progress/LoadingCircularProgress';
 
+/**
+ * StockNewsSummaryProps
+ *
+ * The props used to display a brief summary of recent stock news articles.
+ */
 interface StockNewsSummaryProps {
   loading: boolean;
   summary: string | undefined;
 }
 
+/**
+ * StockNewsSummary
+ *
+ * This component displays a brief summary of recent news articles related to the stock.
+ * It is visually designed to be engaging but not distracting.
+ *
+ * @param props
+ * @constructor
+ */
 const StockNewsSummary: React.FC<StockNewsSummaryProps> = (props) => {
+  if (props.loading || props.summary === undefined) {
+    return <LoadingCircularProgress />;
+  }
+
   return (
-    <>
-      {props.loading || props.summary === undefined ? (
-        <LoadingCircularProgress />
-      ) : (
-        <Container maxWidth="md">
-          <CssBaseline />
-          <Box
-            sx={{
-              mt: 20,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              borderRadius: 2,
-              boxShadow: 3,
-              padding: 2,
-            }}
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <CssBaseline />
+      <Card
+        sx={{
+          borderRadius: 2,
+          boxShadow: 2,
+          padding: 2,
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <CardContent>
+          <Typography
+            variant="h6"
+            component="div"
+            sx={{ mb: 2, fontWeight: 'bold' }}
           >
-            <p>{props.summary}</p>
-          </Box>
-        </Container>
-      )}
-    </>
+            Recent Stock News
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            {props.summary}
+          </Typography>
+        </CardContent>
+      </Card>
+    </Container>
   );
 };
 

--- a/src/components/stock/StockOverview.tsx
+++ b/src/components/stock/StockOverview.tsx
@@ -1,8 +1,23 @@
-import LoadingCircularProgress from '../progress/LoadingCircularProgress';
-import { Stock } from '../../api/methods/GetStock';
 import React from 'react';
-import { Container, CssBaseline, Typography } from '@mui/material';
-import Box from '@mui/material/Box';
+import { Stock } from '../../api/methods/GetStock';
+import LoadingCircularProgress from '../progress/LoadingCircularProgress';
+import {
+  Container,
+  CssBaseline,
+  Typography,
+  Card,
+  CardContent,
+  Box,
+  Link,
+  Divider,
+} from '@mui/material';
+import {
+  Business,
+  Info,
+  ShowChart,
+  LocationCity,
+  Web,
+} from '@mui/icons-material';
 
 /**
  * StockOverviewProps
@@ -26,52 +41,102 @@ interface StockOverviewProps {
  * @constructor
  */
 const StockOverview: React.FC<StockOverviewProps> = (props) => {
+  if (props.loading || props.stock === undefined) {
+    return <LoadingCircularProgress />;
+  }
+
+  const { stock } = props;
+
   return (
-    <>
-      {props.loading || props.stock === undefined ? (
-        <LoadingCircularProgress />
-      ) : (
-        <Container maxWidth="md">
-          <CssBaseline />
-          <Box
-            sx={{
-              mt: 20,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              borderRadius: 2,
-              boxShadow: 3,
-              padding: 2,
-            }}
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <CssBaseline />
+      <Card sx={{ borderRadius: 2, boxShadow: 3 }}>
+        <CardContent>
+          <Typography
+            variant="h5"
+            component="div"
+            sx={{ fontWeight: 'bold', mb: 2 }}
           >
-            <Typography variant="subtitle1">
-              Symbol: {props.stock.symbol}
-            </Typography>
-            <Typography variant="subtitle1">
-              Company: {props.stock.company}
-            </Typography>
-            <Typography variant="subtitle1">
-              Description: {props.stock.description}
-            </Typography>
-            <Typography variant="subtitle1">
-              Exchange: {props.stock.exchange}
-            </Typography>
-            <Typography variant="subtitle1">
-              Sector: {props.stock.sector}
-            </Typography>
-            <Typography variant="subtitle1">
-              Industry: {props.stock.industry}
-            </Typography>
-            <Typography variant="subtitle1">
-              Official Site: {props.stock.official_site}
-            </Typography>
-            <Typography variant="subtitle1">
-              Address: {props.stock.address}
+            Stock Overview
+          </Typography>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Business sx={{ mr: 1, color: 'primary.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Symbol:
+              </Typography>
+              <Typography variant="body1" sx={{ ml: 1 }}>
+                {stock.symbol}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Info sx={{ mr: 1, color: 'secondary.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Company:
+              </Typography>
+              <Typography variant="body1" sx={{ ml: 1 }}>
+                {stock.company}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <ShowChart sx={{ mr: 1, color: 'success.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Sector:
+              </Typography>
+              <Typography variant="body1" sx={{ ml: 1 }}>
+                {stock.sector}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <ShowChart sx={{ mr: 1, color: 'info.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Industry:
+              </Typography>
+              <Typography variant="body1" sx={{ ml: 1 }}>
+                {stock.industry}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <LocationCity sx={{ mr: 1, color: 'warning.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Address:
+              </Typography>
+              <Typography variant="body1" sx={{ ml: 1 }}>
+                {stock.address}
+              </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Web sx={{ mr: 1, color: 'primary.main' }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+                Official Site:
+              </Typography>
+              <Link
+                href={stock.official_site}
+                target="_blank"
+                sx={{ ml: 1 }}
+                variant="body1"
+              >
+                {stock.official_site}
+              </Link>
+            </Box>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              Exchange: {stock.exchange}
             </Typography>
           </Box>
-        </Container>
-      )}
-    </>
+        </CardContent>
+      </Card>
+    </Container>
   );
 };
 

--- a/src/pages/StockDashboardPage.tsx
+++ b/src/pages/StockDashboardPage.tsx
@@ -6,6 +6,7 @@ import StockOverview from '../components/stock/StockOverview';
 import { GetNewsSummaryResponse } from '../api/methods/GetNewsSummary';
 import StockNewsSummary from '../components/stock/StockNewsSummary';
 import { GetPricesResponse, Price } from '../api/methods/GetPrices';
+import StockLineGraph from '../components/stock/StockLineGraph';
 
 const StockDashboardPage: React.FC = (props) => {
   const params: Readonly<Params> = useParams();
@@ -58,6 +59,11 @@ const StockDashboardPage: React.FC = (props) => {
   return (
     <>
       <StockOverview loading={stockLoading} stock={stock} />
+      <StockLineGraph
+        loading={pricesLoading && stockLoading}
+        stock={stock}
+        prices={prices}
+      />
       <StockNewsSummary loading={summaryLoading} summary={summary} />
     </>
   );


### PR DESCRIPTION
This PR adds links from the Portfolio dashboard page to corresponding Stock overview pages for stocks included in the user's portfolio.

Walter now has the ability to provide AI stock summaries and there is a new page to display the summarized info. However, this new page is not routable on the site yet because no user interactions link to the new page...

This PR adds the linking from the Portfolio dashboard pie chart to the Stock overview page for each included stock. 