### PR TITLE
feat: Integrate SearchStocks API with search bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   NEWSLETTER_PAGE,
   REGISTER_PAGE,
   RESET_PASSWORD_PAGE,
+  SEARCH_STOCKS_PAGE,
   SEND_VERIFY_EMAIL_PAGE,
   STOCK_DASHBOARD_PAGE,
   UNSUBSCRIBE_PAGE,
@@ -34,6 +35,7 @@ import UnsubscribePage from './pages/UnsubscribePage';
 import UserNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
 import userNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
 import StockDashboardPage from './pages/StockDashboardPage';
+import SearchStocksPage from './pages/SearchStocksPage';
 
 /**
  * Walter App
@@ -112,6 +114,7 @@ const App: React.FC = () => {
                 path={STOCK_DASHBOARD_PAGE}
                 element={<StockDashboardPage />}
               />
+              <Route path={SEARCH_STOCKS_PAGE} element={<SearchStocksPage />} />
             </Routes>
             <UserNotVerifiedAlert
               userNotVerified={userNotVerifiedAlert}

--- a/src/api/WalterAPI.ts
+++ b/src/api/WalterAPI.ts
@@ -30,6 +30,7 @@ import {
   getNewsSummary,
   GetNewsSummaryResponse,
 } from './methods/GetNewsSummary';
+import { searchStocks, SearchStocksResponse } from './methods/SearchStocks';
 
 /**
  * Walter API
@@ -207,5 +208,14 @@ export class WalterAPI {
   public static async unsubscribe(): Promise<UnsubscribeResponse> {
     const token: string = getCookie('WalterToken') as string;
     return unsubscribe(WalterAPI.ENDPOINT, token);
+  }
+
+  /**
+   * Search for stocks similar to the given symbol.
+   */
+  public static async searchStocks(
+    symbol: string,
+  ): Promise<SearchStocksResponse> {
+    return searchStocks(WalterAPI.ENDPOINT, symbol);
   }
 }

--- a/src/api/common/Methods.ts
+++ b/src/api/common/Methods.ts
@@ -18,3 +18,4 @@ export const CHANGE_PASSWORD_METHOD: string = 'ChangePassword';
 export const SEND_CHANGE_PASSWORD_EMAIL_METHOD: string =
   'SendChangePasswordEmail';
 export const GET_NEWS_SUMMARY_METHOD: string = 'GetNewsSummary';
+export const SEARCH_STOCKS_METHOD: string = 'SearchStocks';

--- a/src/api/methods/SearchStocks.ts
+++ b/src/api/methods/SearchStocks.ts
@@ -1,0 +1,47 @@
+import { WalterAPIResponseBase } from '../common/Response';
+import axios, { AxiosResponse } from 'axios';
+import { SEARCH_STOCKS_METHOD } from '../common/Methods';
+
+export interface StockSearch {
+  symbol: string;
+  name: string;
+  type: string;
+  region: string;
+  currency: string;
+  match_score: string;
+}
+
+export class SearchStocksResponse extends WalterAPIResponseBase {
+  private readonly stockSearchList: StockSearch[];
+
+  constructor(status: string, message: string, data?: any) {
+    super(SEARCH_STOCKS_METHOD, status, message);
+    this.stockSearchList = this.parseData(data)!;
+  }
+
+  public getStocks(): StockSearch[] {
+    return this.stockSearchList;
+  }
+
+  private parseData(data: any): StockSearch[] {
+    if (data === undefined) {
+      return [];
+    }
+    return data.stocks;
+  }
+}
+
+export async function searchStocks(
+  endpoint: string,
+  symbol: string,
+): Promise<SearchStocksResponse> {
+  const response: AxiosResponse = await axios({
+    method: 'GET',
+    url: `${endpoint}/stocks/search?symbol=${symbol}`,
+  });
+  return new SearchStocksResponse(
+    response.data['Status'],
+    response.data['Message'],
+    response.data['Data'],
+  );
+}

--- a/src/components/header/SearchBar.tsx
+++ b/src/components/header/SearchBar.tsx
@@ -64,7 +64,7 @@ const SearchBar: FC = () => {
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      navigate(`/${search.toLowerCase()}`);
+      navigate(`/stocks/search/${search.toLowerCase()}`);
     }
   };
 

--- a/src/components/portfolio/linechart/PortfolioStockLineChart.tsx
+++ b/src/components/portfolio/linechart/PortfolioStockLineChart.tsx
@@ -93,11 +93,13 @@ const PortfolioStockLineChart: FC<PortfolioStockLineChartProps> = (
       return (
         <Typography
           variant="subtitle1"
-          onClick={() => navigate(`/stocks/${props.stock.symbol.toLowerCase()}`)}
+          onClick={() =>
+            navigate(`/stocks/${props.stock.symbol.toLowerCase()}`)
+          }
           sx={{
             cursor: 'pointer',
             textDecoration: 'none',
-            color: 'inherit'
+            color: 'inherit',
           }}
         >
           <Link>{props.stock.symbol}</Link>
@@ -107,11 +109,13 @@ const PortfolioStockLineChart: FC<PortfolioStockLineChartProps> = (
       return (
         <Typography variant="subtitle1">
           <Link
-            onClick={() => navigate(`/stocks/${props.stock.symbol.toLowerCase()}`)}
+            onClick={() =>
+              navigate(`/stocks/${props.stock.symbol.toLowerCase()}`)
+            }
             sx={{
               cursor: 'pointer',
               textDecoration: 'none',
-              color: 'inherit'
+              color: 'inherit',
             }}
           >
             {props.stock.company} ({props.stock.symbol})

--- a/src/pages/SearchStocksPage.tsx
+++ b/src/pages/SearchStocksPage.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import {
+  NavigateFunction,
+  Params,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
+import { WalterAPI } from '../api/WalterAPI';
+import { SearchStocksResponse, StockSearch } from '../api/methods/SearchStocks';
+import LoadingCircularProgress from '../components/progress/LoadingCircularProgress';
+import { Box, Card, CardContent, Link, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid2';
+
+const SearchStocksPage: React.FC = () => {
+  const params: Readonly<Params> = useParams();
+  const navigate: NavigateFunction = useNavigate();
+  const [stocksLoading, setStocksLoading] = useState(false);
+  const [stocks, setStocks] = useState<StockSearch[]>([]);
+
+  useEffect(() => {
+    setStocksLoading(true);
+    WalterAPI.searchStocks(params.symbol as string)
+      .then((response: SearchStocksResponse) => {
+        setStocks(response.getStocks());
+      })
+      .finally(() => setStocksLoading(false));
+  }, [params.symbol]);
+
+  if (stocksLoading) {
+    return <LoadingCircularProgress />;
+  }
+
+  if (!stocks || stocks.length === 0) {
+    return <Typography variant="h6">No stocks found</Typography>;
+  }
+
+  return (
+    <Box sx={{ flexGrow: 1, padding: 2 }}>
+      <Typography variant="h4" gutterBottom>
+        Search Results ({stocks.length} Stocks)
+      </Typography>
+      <Grid container direction="column" spacing={2}>
+        {stocks.map((stock) => (
+          <Grid>
+            <Link
+              onClick={() => navigate(`/stocks/${stock.symbol.toLowerCase()}`)}
+              style={{ textDecoration: 'none', cursor: 'pointer' }}
+            >
+              <Card
+                variant="outlined"
+                sx={{ width: '100%', maxWidth: 800, margin: 'auto' }}
+              >
+                <CardContent>
+                  <Typography variant="h6" gutterBottom>
+                    {stock.name}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    Symbol: {stock.symbol}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    Type: {stock.type}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    Region: {stock.region}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Link>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default SearchStocksPage;

--- a/src/pages/common/Pages.ts
+++ b/src/pages/common/Pages.ts
@@ -12,3 +12,4 @@ export const CHANGE_PASSWORD_PAGE = '/password';
 export const RESET_PASSWORD_PAGE = '/reset-password';
 export const UNSUBSCRIBE_PAGE = '/unsubscribe';
 export const STOCK_DASHBOARD_PAGE = '/stocks/:symbol';
+export const SEARCH_STOCKS_PAGE = 'stocks/search/:symbol';


### PR DESCRIPTION
This PR integrates input into the header search bar with the new `SearchStocks` API. 

This allows Walter to search for stocks given a string and enumerate the return with links to their respective stock summaries.

In short, the search bar for Walter used to be worthless, now its not. 