### PR TITLE
fix: Stop loading symbol after API calls finish for PortfolioDashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,6 @@ import NewslettersPage from './pages/NewslettersPage';
 import PortfolioDashboardPage from './pages/PortfolioDashboardPage';
 import UnsubscribePage from './pages/UnsubscribePage';
 import UserNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
-import userNotSubscribedAlert from './components/alerts/UserNotSubscribedAlert';
 import StockDashboardPage from './pages/StockDashboardPage';
 import SearchStocksPage from './pages/SearchStocksPage';
 

--- a/src/api/methods/GetNewsSummary.ts
+++ b/src/api/methods/GetNewsSummary.ts
@@ -1,7 +1,6 @@
 import { WalterAPIResponseBase } from '../common/Response';
 import { GET_NEWS_SUMMARY_METHOD } from '../common/Methods';
 import axios, { AxiosResponse } from 'axios';
-import { GetStockResponse } from './GetStock';
 
 /**
  * GetNewsSummaryResponse

--- a/src/components/header/SearchBar.tsx
+++ b/src/components/header/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, FormEvent, useState } from 'react';
+import React, { ChangeEvent, FC, useState } from 'react';
 import { alpha, styled } from '@mui/material/styles';
 import InputBase from '@mui/material/InputBase';
 import SearchIcon from '@mui/icons-material/Search';

--- a/src/components/password/SendChangePasswordEmail.tsx
+++ b/src/components/password/SendChangePasswordEmail.tsx
@@ -12,7 +12,6 @@ import {
 import Box from '@mui/material/Box';
 import KeyIcon from '@mui/icons-material/Key';
 import LoadingButton from '../button/LoadingButton';
-import Typography from '@mui/material/Typography';
 
 /**
  * The send change password email component.

--- a/src/components/portfolio/datagrid/PortfolioDataGridV2.tsx
+++ b/src/components/portfolio/datagrid/PortfolioDataGridV2.tsx
@@ -1,12 +1,10 @@
 import { PortfolioStock } from '../../../api/methods/GetPortfolio';
 import React, { useEffect } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box } from '@mui/material';
 import {
   DataGrid,
   GridActionsCellItem,
   GridColDef,
-  GridEventListener,
-  GridRowEditStopReasons,
   GridRowId,
   GridRowModesModel,
   GridSlots,

--- a/src/components/portfolio/linechart/PortfolioStockLineChart.tsx
+++ b/src/components/portfolio/linechart/PortfolioStockLineChart.tsx
@@ -7,7 +7,6 @@ import { Container, Link, Typography, useMediaQuery } from '@mui/material';
 import { US_DOLLAR } from '../../../constants/Constants';
 import { PortfolioStock } from '../../../api/methods/GetPortfolio';
 import theme from '../../../theme/Theme';
-import StringRotator from '../../utils/StringRotator';
 import PortfolioStockDelta from './PortfolioStockDelta';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 
@@ -65,6 +64,9 @@ const PortfolioStockLineChart: FC<PortfolioStockLineChartProps> = (
    * Get the start price of the stock at the start of the time period.
    */
   const getStartPrice = () => {
+    if (props.prices.length === 0) {
+      return 0;
+    }
     return props.prices[0].price;
   };
 
@@ -72,6 +74,9 @@ const PortfolioStockLineChart: FC<PortfolioStockLineChartProps> = (
    * Get the end price of the stock at the end of the time period.
    */
   const getEndPrice = () => {
+    if (props.prices.length === 0) {
+      return 0;
+    }
     return props.prices[props.prices.length - 1].price;
   };
 
@@ -79,8 +84,21 @@ const PortfolioStockLineChart: FC<PortfolioStockLineChartProps> = (
    * Get the delta of the stock over the given time period.
    */
   const getDelta = (): number => {
+    if (props.prices.length === 0) {
+      return 0;
+    }
     return (getEndPrice() - getStartPrice()) / getStartPrice();
   };
+
+  if (props.prices.length === 0) {
+    return (
+      <Container>
+        <Typography variant="subtitle1">
+          No stock prices available for this stock.
+        </Typography>
+      </Container>
+    );
+  }
 
   /**
    * Get the stock identifier for the stock line chart title.

--- a/src/components/portfolio/linechart/PortfolioStockLineChartWidget.tsx
+++ b/src/components/portfolio/linechart/PortfolioStockLineChartWidget.tsx
@@ -10,65 +10,81 @@ import LoadingCircularProgress from '../../progress/LoadingCircularProgress';
 import theme from '../../../theme/Theme';
 
 interface PortfolioStockLineChartWidgetProps {
-  loading: boolean;
+  loading: boolean; // the loading boolean state for parent component GetPortfolio API call
   stocks: PortfolioStock[];
 }
 
 const PortfolioStockLineChartWidget: React.FC<
   PortfolioStockLineChartWidgetProps
 > = (props) => {
-  const [page, setPage] = useState<number>(1);
+  const [page, setPage] = useState<number>(1); // pagination component starts pages list at 1 (not zero-indexed)
   const [stock, setStock] = useState<PortfolioStock>();
   const [prices, setPrices] = useState<Price[]>([]);
-  const [stockLoading, setStockLoading] = useState<boolean>(true);
+  const [pricesLoading, setPricesLoading] = useState<boolean>(true);
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   useEffect(() => {
-    if (props.stocks !== undefined && props.stocks.length > 0) {
+    setPricesLoading(true);
+
+    // if parent component (PortfolioDashboardPage) is still loading GetPortfolio API call, keep stocks loading symbol
+    if (props.loading) {
+      return;
+    }
+
+    // if parent component (PortfolioDashboardPage) finished GetPortfolio API call but portfolio is empty, do not
+    // get stock prices via GetPrices API and unset stock loading symbol
+    if (props.stocks.length === 0) {
+      setPricesLoading(false);
+      setStock(undefined);
+      setPrices([]);
+    }
+
+    // if parent component (PortfolioDashboardPage) finished GetPortfolio API call and portfolio contains stocks,
+    // set the current stock as the first stock in response and then call GetPrices API to get stock prices
+    if (props.stocks.length > 0) {
       setStock(props.stocks[page - 1]);
-      setStockLoading(true);
+      setPricesLoading(true);
       WalterAPI.getPrices(props.stocks[page - 1].symbol)
         .then((response: GetPricesResponse) => setPrices(response.getPrices()))
         .catch((error) => console.log(error))
-        .finally(() => setStockLoading(false));
+        .finally(() => setPricesLoading(false));
     }
-  }, [page, props.stocks]);
+  }, [page, props.stocks, props.loading]);
+
+  // if either parent component GetPortfolio API call or GetPrices API call is still in progress, return loading symbol
+  if (props.loading || pricesLoading) {
+    return <LoadingCircularProgress />;
+  }
 
   return (
-    <>
-      {props.loading || stockLoading ? (
-        <LoadingCircularProgress />
-      ) : (
-        <Container>
-          <PortfolioStockLineChart
-            loading={props.loading}
-            stock={stock as PortfolioStock}
-            prices={prices}
-          />
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <Pagination
-              count={props.stocks.length}
-              size={'small'}
-              page={page}
-              onChange={(event, value) => setPage(value)}
-              style={{ marginTop: '5px' }}
-              sx={{
-                '& .MuiPaginationItem-root': {
-                  fontFamily: 'Raleway, sans-serif',
-                  fontSize: '16px',
-                },
-              }}
-            />
-          </Box>
-        </Container>
-      )}
-    </>
+    <Container>
+      <PortfolioStockLineChart
+        loading={pricesLoading}
+        stock={stock as PortfolioStock}
+        prices={prices}
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Pagination
+          count={props.stocks.length}
+          size={'small'}
+          page={page}
+          onChange={(event, value) => setPage(value)}
+          style={{ marginTop: '5px' }}
+          sx={{
+            '& .MuiPaginationItem-root': {
+              fontFamily: 'Raleway, sans-serif',
+              fontSize: '16px',
+            },
+          }}
+        />
+      </Box>
+    </Container>
   );
 };
 

--- a/src/pages/SearchStocksPage.tsx
+++ b/src/pages/SearchStocksPage.tsx
@@ -1,20 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import {
-  NavigateFunction,
-  Params,
-  useNavigate,
-  useParams,
-} from 'react-router-dom';
+import { Params, useParams } from 'react-router-dom';
 import { WalterAPI } from '../api/WalterAPI';
 import { SearchStocksResponse, StockSearch } from '../api/methods/SearchStocks';
 import LoadingCircularProgress from '../components/progress/LoadingCircularProgress';
-import { Box, Card, CardContent, Link, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import StockSearchResult from '../components/stock/StockSearchResult';
 
 const SearchStocksPage: React.FC = () => {
   const params: Readonly<Params> = useParams();
-  const navigate: NavigateFunction = useNavigate();
   const [stocksLoading, setStocksLoading] = useState(false);
   const [stocks, setStocks] = useState<StockSearch[]>([]);
 


### PR DESCRIPTION
For the `PortfolioDashboard` page, the page orchestrates calling the `GetPortfolio` API to get user portfolio information to render on the dashboard. 

The portfolio is rendered via a couple different components by passing down the `GetPortfolio` API response to the child components. 

While the `GePortfolio` API call is in progress, the child components should display loading symbols to let the user know work is in progress in the backend.

For the stock line chart component specifically, the `GetPrices` API is called after the `GetPortfolio` response to get pricing data to display for each stock. However, there were a lot of edge cases that caused Walter to crash when the portfolio was empty. This PR fixes those (or seems to? hmmmm 🤔).